### PR TITLE
Add ADS1115 #2 (0x49) for oil temp, oil pressure, and lift pump pressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ This project uses a Teensy 4.1 for real-time embedded control of a Variable Geom
 
 | Channel | Sensor | Type | Notes |
 |---------|--------|------|-------|
-| A0 | Lift Pump Pressure (temporary, until OSSM) | 0.5–4.5V pressure transducer | |
-| A1 | TOP — Turbine Output Pressure | 0.5–4.5V pressure transducer | |
-| A2 | Oil Temp | - | |
-| A3 | Oil Pressure | 0.5–4.5V pressure transducer | |
+| A0 | TOP — Turbine Out Pressure | 0.5–4.5V pressure transducer | 30 PSI default — verify sensor rating |
+| A1 | Oil Pressure | 0.5–4.5V pressure transducer | 100 PSI |
+| A2 | Oil Temp | GM NTC thermistor, 2.2kΩ pulldown | Same family as CIT |
+| A3 | Fuel Lift Pump Pressure (temporary) | 0.5–4.5V pressure transducer | 15 PSI |
 
 ### MAX31856 Thermocouple Channels
 

--- a/include/AppData.h
+++ b/include/AppData.h
@@ -20,6 +20,8 @@ struct AppData {
     int16_t compressorOutputTempC;
     int16_t turbineOutletTempC;
     int16_t oilTempC;
+    uint16_t oilPressureHpa;
+    uint16_t turbineOutPressureHpa;
     uint16_t liftPumpPressureHpa;
     uint16_t ambientPressureGuessHpa;
     bool pgFault;

--- a/src/sensors/adcSensors.cpp
+++ b/src/sensors/adcSensors.cpp
@@ -4,9 +4,11 @@
 #include <math.h>
 
 static Adafruit_ADS1115 ads;
+static Adafruit_ADS1115 ads2;
 
 static const uint32_t CONVERSION_TIMEOUT_MS = 5;
 static const uint8_t READY_PIN = 41;
+static const uint8_t READY_PIN_2 = 21;
 static const float TIP_ZERO_SAFETY_MIN = 0.25f;
 
 // ADS1115 single-ended mux configs for channels 0-3
@@ -37,18 +39,29 @@ static void IRAM_ATTR ConversionReadyISR() {
     conversionReady = true;
 }
 
+static volatile bool conversionReady2 = false;
+static void IRAM_ATTR ConversionReadyISR2() {
+    conversionReady2 = true;
+}
+
 uint8_t AdcSensors::currentChannel = 0;
 bool AdcSensors::conversionStarted = false;
 uint32_t AdcSensors::conversionStartTime = 0;
 float AdcSensors::ema[NUM_CHANNELS] = {0};
 bool AdcSensors::emaInitialized[NUM_CHANNELS] = {false};
 
+uint8_t AdcSensors::currentChannel2 = 0;
+bool AdcSensors::conversionStarted2 = false;
+uint32_t AdcSensors::conversionStartTime2 = 0;
+float AdcSensors::ema2[NUM_CHANNELS] = {0};
+bool AdcSensors::emaInitialized2[NUM_CHANNELS] = {false};
+
 void AdcSensors::Initialize() {
     ads.setGain(GAIN_TWOTHIRDS); // +/-6.144V range for 5V sensors
     ads.setDataRate(RATE_ADS1115_860SPS);
 
     if (!ads.begin()) {
-        Serial.println("ADS1115 #1 not found, check wiring!");
+        Serial.println("ADS1115 #1 (0x48) not found, check wiring!");
         return;
     }
 
@@ -59,7 +72,21 @@ void AdcSensors::Initialize() {
     conversionStarted = false;
     appData.tipZeroVoltage = 0.5f;
 
-    Serial.println("AdcSensors initialized (4-channel round-robin)");
+    ads2.setGain(GAIN_TWOTHIRDS);
+    ads2.setDataRate(RATE_ADS1115_860SPS);
+
+    if (!ads2.begin(0x49)) {
+        Serial.println("ADS1115 #2 (0x49) not found, check wiring!");
+        return;
+    }
+
+    pinMode(READY_PIN_2, INPUT);
+    attachInterrupt(digitalPinToInterrupt(READY_PIN_2), ConversionReadyISR2, FALLING);
+
+    currentChannel2 = 0;
+    conversionStarted2 = false;
+
+    Serial.println("AdcSensors initialized (2x 4-channel round-robin)");
 }
 
 void AdcSensors::startConversion(uint8_t channel) {
@@ -67,6 +94,13 @@ void AdcSensors::startConversion(uint8_t channel) {
     ads.startADCReading(MUX_CONFIG[channel], /*continuous=*/false);
     conversionStarted = true;
     conversionStartTime = millis();
+}
+
+void AdcSensors::startConversion2(uint8_t channel) {
+    conversionReady2 = false;
+    ads2.startADCReading(MUX_CONFIG[channel], /*continuous=*/false);
+    conversionStarted2 = true;
+    conversionStartTime2 = millis();
 }
 
 void AdcSensors::update() {
@@ -100,6 +134,35 @@ void AdcSensors::update() {
     processResult(currentChannel, ema[currentChannel]);
     conversionStarted = false;
     currentChannel = (currentChannel + 1) % NUM_CHANNELS;
+
+    // ADS2 (0x49) round-robin
+    if (!conversionStarted2) {
+        startConversion2(currentChannel2);
+        return;
+    }
+
+    if (millis() - conversionStartTime2 > CONVERSION_TIMEOUT_MS) {
+        conversionStarted2 = false;
+        return;
+    }
+
+    if (!conversionReady2) {
+        return;
+    }
+
+    int16_t raw2 = ads2.getLastConversionResults();
+    float voltage2 = ads2.computeVolts(raw2);
+
+    if (!emaInitialized2[currentChannel2]) {
+        ema2[currentChannel2] = voltage2;
+        emaInitialized2[currentChannel2] = true;
+    } else {
+        ema2[currentChannel2] += EMA_ALPHA * (voltage2 - ema2[currentChannel2]);
+    }
+
+    processResult2(currentChannel2, ema2[currentChannel2]);
+    conversionStarted2 = false;
+    currentChannel2 = (currentChannel2 + 1) % NUM_CHANNELS;
 }
 
 void AdcSensors::processResult(uint8_t channel, float voltage) {
@@ -144,6 +207,45 @@ void AdcSensors::processResult(uint8_t channel, float voltage) {
             if (hPa < 0.0f) hPa = 0.0f;
             if (hPa > 6895.0f) hPa = 6895.0f;
             appData.turbineInputPressureHpa = (uint16_t)hPa;
+            break;
+        }
+    }
+}
+
+void AdcSensors::processResult2(uint8_t channel, float voltage) {
+    switch (channel) {
+        case 0: {
+            // TOP — turbine out pressure, 0.5–4.5V ratiometric
+            // TODO: verify sensor PSI rating; using 30 PSI (2068 hPa) as default
+            float hPa = (voltage - 0.5f) * 517.0f;
+            if (hPa < 0.0f) hPa = 0.0f;
+            if (hPa > 2068.0f) hPa = 2068.0f;
+            appData.turbineOutPressureHpa = (uint16_t)hPa;
+            break;
+        }
+        case 1: {
+            // Oil pressure: 100 PSI (6895 hPa), 0.5–4.5V ratiometric
+            float hPa = (voltage - 0.5f) * 1723.69f;
+            if (hPa < 0.0f) hPa = 0.0f;
+            if (hPa > 6895.0f) hPa = 6895.0f;
+            appData.oilPressureHpa = (uint16_t)hPa;
+            break;
+        }
+        case 2: {
+            // Oil temp: GM NTC + 2.2kΩ pulldown to GND, 5V supply
+            if (voltage >= NTC_VCC - 0.01f || voltage <= 0.01f) {
+                break;
+            }
+            float resistance = PULLDOWN_R * voltage / (NTC_VCC - voltage);
+            appData.oilTempC = (int16_t)steinhartHart(resistance);
+            break;
+        }
+        case 3: {
+            // Fuel lift pump pressure: 15 PSI (1034 hPa), 0.5–4.5V ratiometric
+            float hPa = (voltage - 0.5f) * 258.575f;
+            if (hPa < 0.0f) hPa = 0.0f;
+            if (hPa > 1034.0f) hPa = 1034.0f;
+            appData.liftPumpPressureHpa = (uint16_t)hPa;
             break;
         }
     }

--- a/src/sensors/adcSensors.cpp
+++ b/src/sensors/adcSensors.cpp
@@ -104,65 +104,43 @@ void AdcSensors::startConversion2(uint8_t channel) {
 }
 
 void AdcSensors::update() {
+    // ADS1 (0x48) — independent state machine
     if (!conversionStarted) {
         startConversion(currentChannel);
-        return;
-    }
-
-    // Check for timeout — retry same channel
-    if (millis() - conversionStartTime > CONVERSION_TIMEOUT_MS) {
+    } else if (millis() - conversionStartTime > CONVERSION_TIMEOUT_MS) {
         conversionStarted = false;
-        return;
+    } else if (conversionReady) {
+        int16_t raw = ads.getLastConversionResults();
+        float voltage = ads.computeVolts(raw);
+        if (!emaInitialized[currentChannel]) {
+            ema[currentChannel] = voltage;
+            emaInitialized[currentChannel] = true;
+        } else {
+            ema[currentChannel] += EMA_ALPHA * (voltage - ema[currentChannel]);
+        }
+        processResult(currentChannel, ema[currentChannel]);
+        conversionStarted = false;
+        currentChannel = (currentChannel + 1) % NUM_CHANNELS;
     }
 
-    // Wait for ISR to signal conversion complete
-    if (!conversionReady) {
-        return;
-    }
-
-    // Read result, apply EMA, process, advance
-    int16_t raw = ads.getLastConversionResults();
-    float voltage = ads.computeVolts(raw);
-
-    if (!emaInitialized[currentChannel]) {
-        ema[currentChannel] = voltage;
-        emaInitialized[currentChannel] = true;
-    } else {
-        ema[currentChannel] += EMA_ALPHA * (voltage - ema[currentChannel]);
-    }
-
-    processResult(currentChannel, ema[currentChannel]);
-    conversionStarted = false;
-    currentChannel = (currentChannel + 1) % NUM_CHANNELS;
-
-    // ADS2 (0x49) round-robin
+    // ADS2 (0x49) — independent state machine, always runs every call
     if (!conversionStarted2) {
         startConversion2(currentChannel2);
-        return;
-    }
-
-    if (millis() - conversionStartTime2 > CONVERSION_TIMEOUT_MS) {
+    } else if (millis() - conversionStartTime2 > CONVERSION_TIMEOUT_MS) {
         conversionStarted2 = false;
-        return;
+    } else if (conversionReady2) {
+        int16_t raw2 = ads2.getLastConversionResults();
+        float voltage2 = ads2.computeVolts(raw2);
+        if (!emaInitialized2[currentChannel2]) {
+            ema2[currentChannel2] = voltage2;
+            emaInitialized2[currentChannel2] = true;
+        } else {
+            ema2[currentChannel2] += EMA_ALPHA * (voltage2 - ema2[currentChannel2]);
+        }
+        processResult2(currentChannel2, ema2[currentChannel2]);
+        conversionStarted2 = false;
+        currentChannel2 = (currentChannel2 + 1) % NUM_CHANNELS;
     }
-
-    if (!conversionReady2) {
-        return;
-    }
-
-    int16_t raw2 = ads2.getLastConversionResults();
-    float voltage2 = ads2.computeVolts(raw2);
-
-    if (!emaInitialized2[currentChannel2]) {
-        ema2[currentChannel2] = voltage2;
-        emaInitialized2[currentChannel2] = true;
-    } else {
-        ema2[currentChannel2] += EMA_ALPHA * (voltage2 - ema2[currentChannel2]);
-    }
-
-    processResult2(currentChannel2, ema2[currentChannel2]);
-    conversionStarted2 = false;
-    currentChannel2 = (currentChannel2 + 1) % NUM_CHANNELS;
 }
 
 void AdcSensors::processResult(uint8_t channel, float voltage) {

--- a/src/sensors/adcSensors.cpp
+++ b/src/sensors/adcSensors.cpp
@@ -103,8 +103,7 @@ void AdcSensors::startConversion2(uint8_t channel) {
     conversionStartTime2 = millis();
 }
 
-void AdcSensors::update() {
-    // ADS1 (0x48) — independent state machine
+void AdcSensors::updateAds1() {
     if (!conversionStarted) {
         startConversion(currentChannel);
     } else if (millis() - conversionStartTime > CONVERSION_TIMEOUT_MS) {
@@ -122,8 +121,9 @@ void AdcSensors::update() {
         conversionStarted = false;
         currentChannel = (currentChannel + 1) % NUM_CHANNELS;
     }
+}
 
-    // ADS2 (0x49) — independent state machine, always runs every call
+void AdcSensors::updateAds2() {
     if (!conversionStarted2) {
         startConversion2(currentChannel2);
     } else if (millis() - conversionStartTime2 > CONVERSION_TIMEOUT_MS) {
@@ -141,6 +141,11 @@ void AdcSensors::update() {
         conversionStarted2 = false;
         currentChannel2 = (currentChannel2 + 1) % NUM_CHANNELS;
     }
+}
+
+void AdcSensors::update() {
+    updateAds1();
+    updateAds2();
 }
 
 void AdcSensors::processResult(uint8_t channel, float voltage) {

--- a/src/sensors/adcSensors.h
+++ b/src/sensors/adcSensors.h
@@ -10,14 +10,25 @@ class AdcSensors {
     private:
         static const uint8_t NUM_CHANNELS = 4;
         static constexpr float EMA_ALPHA = 0.01f; // ~100-sample smoothing
+
+        // ADS1 (0x48) — boost/CIP/CIT/TIP
         static uint8_t currentChannel;
         static bool conversionStarted;
         static uint32_t conversionStartTime;
         static float ema[NUM_CHANNELS];
         static bool emaInitialized[NUM_CHANNELS];
 
+        // ADS2 (0x49) — TOP/oil pressure/oil temp/lift pump
+        static uint8_t currentChannel2;
+        static bool conversionStarted2;
+        static uint32_t conversionStartTime2;
+        static float ema2[NUM_CHANNELS];
+        static bool emaInitialized2[NUM_CHANNELS];
+
         static void startConversion(uint8_t channel);
         static void processResult(uint8_t channel, float voltage);
+        static void startConversion2(uint8_t channel);
+        static void processResult2(uint8_t channel, float voltage);
         static float steinhartHart(float resistance);
 };
 

--- a/src/sensors/adcSensors.h
+++ b/src/sensors/adcSensors.h
@@ -25,6 +25,8 @@ class AdcSensors {
         static float ema2[NUM_CHANNELS];
         static bool emaInitialized2[NUM_CHANNELS];
 
+        static void updateAds1();
+        static void updateAds2();
         static void startConversion(uint8_t channel);
         static void processResult(uint8_t channel, float voltage);
         static void startConversion2(uint8_t channel);

--- a/src/sensors/j1939.cpp
+++ b/src/sensors/j1939.cpp
@@ -6,10 +6,10 @@
 // CAN2 = Teensy 4.1 pins 0 (RX) / 1 (TX). J1939 @ 250 kbps, 29-bit extended IDs.
 static FlexCAN_T4<CAN2, RX_SIZE_256, TX_SIZE_16> Can1939;
 
-static const uint8_t  SA           = 0x01;
-static const uint32_t PGN_EGT      = 0xFEF6; // SPN 173 — Exhaust Gas Temperature
-static const uint32_t PGN_OIL_TEMP = 0xFEEE; // SPN 175 — Engine Oil Temperature
-static const uint32_t PGN_FUEL_PRS = 0xFEEF; // SPN 94  — Fuel Delivery Pressure
+static const uint8_t  SA              = 0x01;
+static const uint32_t PGN_EGT         = 0xFEF6; // SPN 173 — Exhaust Gas Temperature
+static const uint32_t PGN_OIL_TEMP    = 0xFEEE; // SPN 175 (bytes 2-3) + SPN 176 (bytes 4-5) — Engine Oil Temperature
+static const uint32_t PGN_FLUID_PRESS = 0xFEEF; // SPN 94 (byte 0) fuel, SPN 100 (byte 3) oil pressure
 
 static uint32_t lastTx = 0;
 
@@ -49,17 +49,24 @@ static void transmit() {
     buf[5] = egtRaw >> 8;
     sendPgn(PGN_EGT, buf);
 
-    // Oil Temp — SPN 175, PGN 65262, bytes 2-3, encoding: (temp_c + 273) * 32
+    // Oil Temp — PGN 65262, encoding: (temp_c + 273) * 32
+    // SPN 175 (Engine Oil Temp 1): bytes 2-3
+    // SPN 176 (Turbocharger Oil Temp): bytes 4-5
     memset(buf, 0xFF, 8);
     uint16_t oilTmpRaw = (uint16_t)((appData.oilTempC + 273) * 32);
     buf[2] = oilTmpRaw & 0xFF;
     buf[3] = oilTmpRaw >> 8;
+    buf[4] = oilTmpRaw & 0xFF;
+    buf[5] = oilTmpRaw >> 8;
     sendPgn(PGN_OIL_TEMP, buf);
 
-    // Fuel Pressure — SPN 94, PGN 65263, byte 0, encoding: kPa / 4
+    // Fluid pressures — PGN 65263 (0xFEEF), encoding: kPa / 4
+    // SPN 94 (byte 0): fuel delivery pressure
+    // SPN 100 (byte 3): engine oil pressure
     memset(buf, 0xFF, 8);
     buf[0] = (uint8_t)((appData.liftPumpPressureHpa / 10) / 4);
-    sendPgn(PGN_FUEL_PRS, buf);
+    buf[3] = (uint8_t)((appData.oilPressureHpa / 10) / 4);
+    sendPgn(PGN_FLUID_PRESS, buf);
 }
 
 void J1939::Loop() {


### PR DESCRIPTION
## Summary

- Adds full ADS1115 #2 (I2C 0x49) support with ISR-driven 4-channel round-robin matching the existing ADS1 pattern (READY pin 21)
- AIN0: TOP — Turbine Out Pressure (wired, not yet J1939-transmitted); AIN1: Oil Pressure (100 PSI, SPN 100); AIN2: Oil Temp (GM NTC, same Steinhart-Hart as CIT); AIN3: Fuel Lift Pump Pressure (15 PSI, temporary)
- Updates J1939 TX: SPN 100 (oil pressure) added to PGN 65263 byte 3; SPN 176 (turbocharger oil temp) added alongside SPN 175 in PGN 65262 bytes 4–5
- Adds `oilPressureHpa` and `turbineOutPressureHpa` to `AppData`; updates README ADS2 channel table

## Test plan

- [ ] Verify ADS1115 #2 initializes at 0x49 with `ADS1115 #2 (0x49) not found` absent from serial output when wired
- [ ] Confirm oil pressure, oil temp, and lift pump pressure populate `appData` fields correctly under known voltage inputs
- [ ] Verify PGN 65263 on J1939 bus carries SPN 94 (byte 0) and SPN 100 (byte 3) with correct kPa/4 encoding
- [ ] Verify PGN 65262 on J1939 bus carries SPN 175 (bytes 2–3) and SPN 176 (bytes 4–5) with matching values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jlaustill/ovgt/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
