### PR TITLE
feat(boost): boost-scheduled vane open-cap schedule (tames BPR slam)

### DIFF
--- a/docs/superpowers/plans/2026-07-05-boost-vane-cap-schedule.md
+++ b/docs/superpowers/plans/2026-07-05-boost-vane-cap-schedule.md
@@ -1,0 +1,454 @@
+# Boost Vane Open-Cap Schedule — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat vane open-cap (`vaneOpenCapPercent = 55`) with a boost→open-cap schedule so the BPR PI loop can no longer slam the vane wide open under load.
+
+**Architecture:** A pure, native-tested interpolator (`vaneOpenCapForBoost`) maps boost psi to an open-cap % from a tweakable table; `boostBprStep`'s final clamp uses it instead of the scalar cap. Schedule is wired as nullable trailing fields on `BoostConfig` (null → existing flat-cap behavior), so validated tests stay green. The active cap is surfaced as telemetry `vane_cap`.
+
+**Tech Stack:** C++ (Teensy 4.1 / Arduino / PlatformIO), Unity native tests, Node/TypeScript host tool (vitest).
+
+## Global Constraints
+
+- Vane convention: `0%` = fully closed (max drive/boost), `88%` = fully open. Higher % = more open.
+- Tuning is **compile-time only** — edit source + reflash. NO runtime/serial setters (driving hazard).
+- Floor stays `spoolPercent = 22` (validated; 18 spiked EGT). This change touches the **cap only**.
+- `boostBprStep` is pure and native-tested (`test/test_boost_bpr_logic/`). Keep it pure.
+- No automatic EGT escape this iteration (driver watches TIT + `act_load` live).
+- Production schedule points: `{5,22} {10,25} {15,27} {20,29} {25,31}` (boost psi → cap %).
+- New host telemetry fields are optional (`?`) — older logs lack them.
+- Branch: `feature/boost-vane-cap-schedule`. Build: `pio run -e teensy41`. Native tests: `pio test -e native -f test_boost_bpr_logic`.
+
+---
+
+### Task 1: Pure `vaneOpenCapForBoost` interpolator + config/state fields
+
+**Files:**
+- Modify: `src/control/boostBprLogic.h` (add `VaneCapPoint`, `BoostConfig` schedule fields, `BoostState.lastVaneCap`, declare function)
+- Modify: `src/control/boostBprLogic.cpp` (implement function)
+- Test: `test/test_boost_bpr_logic/test_boost_bpr_logic.cpp` (null-init new config fields in `makeConfig`; add interpolator tests)
+
+**Interfaces:**
+- Produces: `struct VaneCapPoint { float boostPsi; uint8_t capPercent; };`
+- Produces: `uint8_t vaneOpenCapForBoost(float boostPsi, const BoostConfig &cfg);`
+- Produces: `BoostConfig` gains `const VaneCapPoint *vaneCapSchedule;` and `uint8_t vaneCapScheduleLen;` (trailing).
+- Produces: `BoostState` gains trailing `uint8_t lastVaneCap;`
+
+- [ ] **Step 1: Add the struct/field declarations to the header**
+
+In `src/control/boostBprLogic.h`, add above `struct BoostConfig`:
+```c
+struct VaneCapPoint {
+    float   boostPsi;     // schedule breakpoint (ascending)
+    uint8_t capPercent;   // open-cap at/above this boost (until the next point)
+};
+```
+Append to `struct BoostConfig` (after `vaneOpenCapPercent`):
+```c
+    // Boost -> open-cap schedule (ascending boostPsi). NULL / len 0 => use the flat
+    // vaneOpenCapPercent above. Tightens open authority under load so the PI cannot
+    // slam the vane wide open. Floor stays spoolPercent.
+    const VaneCapPoint *vaneCapSchedule;
+    uint8_t             vaneCapScheduleLen;
+```
+Append to `struct BoostState` (after `inPiRegion`):
+```c
+    uint8_t lastVaneCap;  // open-cap used on the last step (for telemetry readout)
+```
+Declare after the `boostBprStep` prototype:
+```c
+// Boost (gauge psi) -> vane open-cap %, linear between ascending schedule points,
+// flat outside the ends. Falls back to cfg.vaneOpenCapPercent when no schedule is
+// wired (cfg.vaneCapSchedule == NULL or cfg.vaneCapScheduleLen == 0).
+uint8_t vaneOpenCapForBoost(float boostPsi, const BoostConfig &cfg);
+```
+
+- [ ] **Step 2: Null-init the new config fields in the test helper**
+
+In `test/test_boost_bpr_logic/test_boost_bpr_logic.cpp`, inside `makeConfig()`, before `return cfg;`, add:
+```c
+    cfg.vaneCapSchedule = nullptr;   // existing tests: flat-cap path
+    cfg.vaneCapScheduleLen = 0;
+```
+(`BoostConfig cfg;` is default-initialized, so the new pointer would be garbage otherwise.)
+
+- [ ] **Step 3: Write the failing interpolator tests**
+
+Append to `test/test_boost_bpr_logic/test_boost_bpr_logic.cpp` (and add matching `RUN_TEST` lines in `main`):
+```c
+static const VaneCapPoint kSchedule[] = {
+    {5.0f, 22}, {10.0f, 25}, {15.0f, 27}, {20.0f, 29}, {25.0f, 31},
+};
+
+void test_vane_cap_null_schedule_falls_back_to_flat(void) {
+    BoostConfig cfg = makeConfig();          // schedule null, vaneOpenCapPercent 55
+    TEST_ASSERT_EQUAL_UINT8(55, vaneOpenCapForBoost(10.0f, cfg));
+}
+
+void test_vane_cap_exact_points(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    TEST_ASSERT_EQUAL_UINT8(22, vaneOpenCapForBoost(5.0f, cfg));
+    TEST_ASSERT_EQUAL_UINT8(25, vaneOpenCapForBoost(10.0f, cfg));
+    TEST_ASSERT_EQUAL_UINT8(29, vaneOpenCapForBoost(20.0f, cfg));
+    TEST_ASSERT_EQUAL_UINT8(31, vaneOpenCapForBoost(25.0f, cfg));
+}
+
+void test_vane_cap_clamps_outside_ends(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    TEST_ASSERT_EQUAL_UINT8(22, vaneOpenCapForBoost(0.0f, cfg));   // below first
+    TEST_ASSERT_EQUAL_UINT8(22, vaneOpenCapForBoost(2.0f, cfg));   // below first
+    TEST_ASSERT_EQUAL_UINT8(31, vaneOpenCapForBoost(30.0f, cfg));  // above last
+}
+
+void test_vane_cap_interpolates_midpoint(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    // 12.5 psi: 25 + (2.5/5)*(27-25) = 26
+    TEST_ASSERT_EQUAL_UINT8(26, vaneOpenCapForBoost(12.5f, cfg));
+}
+```
+Add to `main()`:
+```c
+    RUN_TEST(test_vane_cap_null_schedule_falls_back_to_flat);
+    RUN_TEST(test_vane_cap_exact_points);
+    RUN_TEST(test_vane_cap_clamps_outside_ends);
+    RUN_TEST(test_vane_cap_interpolates_midpoint);
+```
+
+- [ ] **Step 4: Run tests — verify they fail**
+
+Run: `pio test -e native -f test_boost_bpr_logic`
+Expected: FAIL — `undefined reference to vaneOpenCapForBoost` (link error).
+
+- [ ] **Step 5: Implement the interpolator**
+
+In `src/control/boostBprLogic.cpp`, add above `boostBprStep`:
+```c
+uint8_t vaneOpenCapForBoost(float boostPsi, const BoostConfig &cfg) {
+    if (cfg.vaneCapSchedule == nullptr || cfg.vaneCapScheduleLen == 0) {
+        return cfg.vaneOpenCapPercent;
+    }
+    const VaneCapPoint *pts = cfg.vaneCapSchedule;
+    uint8_t n = cfg.vaneCapScheduleLen;
+    if (boostPsi <= pts[0].boostPsi) return pts[0].capPercent;
+    if (boostPsi >= pts[n - 1].boostPsi) return pts[n - 1].capPercent;
+    for (uint8_t i = 1; i < n; i++) {
+        if (boostPsi <= pts[i].boostPsi) {
+            float pLow = pts[i - 1].boostPsi;
+            float pHigh = pts[i].boostPsi;
+            float cLow = (float)pts[i - 1].capPercent;
+            float cHigh = (float)pts[i].capPercent;
+            float cap = cLow + (boostPsi - pLow) / (pHigh - pLow) * (cHigh - cLow);
+            return (uint8_t)(cap + 0.5f);
+        }
+    }
+    return pts[n - 1].capPercent;  // unreachable; satisfies the compiler
+}
+```
+
+- [ ] **Step 6: Run tests — verify they pass**
+
+Run: `pio test -e native -f test_boost_bpr_logic`
+Expected: PASS — all interpolator tests plus every pre-existing test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/control/boostBprLogic.h src/control/boostBprLogic.cpp test/test_boost_bpr_logic/test_boost_bpr_logic.cpp
+git commit -m "feat(boost): pure vaneOpenCapForBoost interpolator + schedule config fields
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire the schedule into `boostBprStep` + record `lastVaneCap`
+
+**Files:**
+- Modify: `src/control/boostBprLogic.cpp` (spool early-return records cap; final clamp uses the schedule cap)
+- Test: `test/test_boost_bpr_logic/test_boost_bpr_logic.cpp` (schedule clamps the open-slam; `lastVaneCap` recorded)
+
+**Interfaces:**
+- Consumes: `vaneOpenCapForBoost(float, const BoostConfig&)`, `BoostState.lastVaneCap` (Task 1).
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to the test file (and `RUN_TEST` in `main`):
+```c
+void test_schedule_clamps_open_slam_to_scheduled_cap(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    BoostInputs in;
+    in.boostGaugePsi = 20.0f;   // schedule cap = 29
+    in.tipGaugePsi = 30.0f;     // bpr 1.5 > target -> wants to open fully
+    BoostState st = {0.0f, false, true, 0};
+    uint8_t vane = boostBprStep(in, cfg, st, 0.01f);
+    TEST_ASSERT_EQUAL_UINT8(29, vane);          // clamped to scheduled cap, not 55
+    TEST_ASSERT_EQUAL_UINT8(29, st.lastVaneCap); // cap recorded for telemetry
+}
+
+void test_spool_region_records_spool_as_cap(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    BoostInputs in;
+    in.boostGaugePsi = 1.0f;    // spool region
+    in.tipGaugePsi = 0.5f;
+    BoostState st = {0.0f, false, false, 0};
+    uint8_t vane = boostBprStep(in, cfg, st, 0.01f);
+    TEST_ASSERT_EQUAL_UINT8(cfg.spoolPercent, vane);
+    TEST_ASSERT_EQUAL_UINT8(cfg.spoolPercent, st.lastVaneCap); // meaningful readout
+}
+```
+Add to `main()`:
+```c
+    RUN_TEST(test_schedule_clamps_open_slam_to_scheduled_cap);
+    RUN_TEST(test_spool_region_records_spool_as_cap);
+```
+
+- [ ] **Step 2: Run tests — verify the new ones fail**
+
+Run: `pio test -e native -f test_boost_bpr_logic`
+Expected: FAIL — `test_schedule_clamps_open_slam...` returns 55 (flat cap still used) and `lastVaneCap` is 0.
+
+- [ ] **Step 3: Wire the schedule into `boostBprStep`**
+
+In `src/control/boostBprLogic.cpp`, in the spool early-return block, record the cap before returning:
+```c
+    if (!state.inPiRegion) {
+        state.wasSpooling = true;
+        state.lastVaneCap = cfg.spoolPercent;   // meaningful readout in spool region
+        return clampVane((float)cfg.spoolPercent,
+                         cfg.vaneClosedPercent, cfg.vaneOpenPercent);
+    }
+```
+Replace the final `return` (currently `return clampVane(vane, cfg.spoolPercent, cfg.vaneOpenCapPercent);`) with:
+```c
+    uint8_t cap = vaneOpenCapForBoost(in.boostGaugePsi, cfg);
+    state.lastVaneCap = cap;
+    return clampVane(vane, cfg.spoolPercent, cap);
+```
+
+- [ ] **Step 4: Run tests — verify all pass**
+
+Run: `pio test -e native -f test_boost_bpr_logic`
+Expected: PASS — all tests, including the pre-existing `test_bpr_above_target_opens` (schedule null → still clamps to `vaneOpenCapPercent`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/boostBprLogic.cpp test/test_boost_bpr_logic/test_boost_bpr_logic.cpp
+git commit -m "feat(boost): clamp PI vane demand to boost-scheduled open cap
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Production schedule table + `getActiveVaneCap()`
+
+**Files:**
+- Modify: `src/control/boostController.cpp` (define `vaneCapSchedule`, wire into `boostConfig`, add getter)
+- Modify: `src/control/boostController.h` (declare getter)
+
+**Interfaces:**
+- Consumes: `VaneCapPoint`, `BoostConfig` schedule fields, `BoostState.lastVaneCap` (Tasks 1-2).
+- Produces: `static uint8_t BoostController::getActiveVaneCap();`
+
+- [ ] **Step 1: Declare the getter**
+
+In `src/control/boostController.h`, add after `getIntegralTerm();`:
+```c
+        // Open-cap (%) the controller applied on the last update — for telemetry so
+        // we can see the vane riding the boost-scheduled cap. See vaneOpenCapForBoost.
+        static uint8_t getActiveVaneCap();
+```
+
+- [ ] **Step 2: Define the schedule table and wire it into the config**
+
+In `src/control/boostController.cpp`, add above `static BoostConfig boostConfig`:
+```c
+// Boost (gauge psi) -> vane open-cap (%). THE tuning knob for the closure/slam
+// strategy: edit these points + reflash. Ascending boost. Floor stays spoolPercent.
+static const VaneCapPoint vaneCapSchedule[] = {
+    { 5.0f, 22 }, { 10.0f, 25 }, { 15.0f, 27 }, { 20.0f, 29 }, { 25.0f, 31 },
+};
+static const uint8_t vaneCapScheduleLen =
+    sizeof(vaneCapSchedule) / sizeof(vaneCapSchedule[0]);
+```
+Append the two new fields to the `boostConfig` aggregate initializer (after the `55` for `vaneOpenCapPercent`):
+```c
+    55,                  // vaneOpenCapPercent (flat fallback if schedule unset)
+    vaneCapSchedule,     // vaneCapSchedule (boost-scheduled open cap; supersedes flat)
+    vaneCapScheduleLen   // vaneCapScheduleLen
+```
+Update the `boostState` initializer to include the new trailing field:
+```c
+static BoostState boostState = {0.0f, true, false, 0};
+```
+
+- [ ] **Step 3: Implement the getter**
+
+In `src/control/boostController.cpp`, add near the other accessors:
+```c
+uint8_t BoostController::getActiveVaneCap() { return boostState.lastVaneCap; }
+```
+In `BoostController::update()`, in the `#else` (MAP mode) branch, keep the readout sane by setting the cap to the flat fallback after the interpolate call:
+```c
+    appData.actuatorDemandedPosition = interpolate(boostGaugePsi);
+    boostState.lastVaneCap = boostConfig.vaneOpenCapPercent;
+```
+
+- [ ] **Step 4: Build the firmware**
+
+Run: `pio run -e teensy41`
+Expected: SUCCESS (`[SUCCESS]`). No link/compile errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/control/boostController.cpp src/control/boostController.h
+git commit -m "feat(boost): production boost->open-cap schedule + getActiveVaneCap
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Emit `vane_cap` in firmware telemetry
+
+**Files:**
+- Modify: `src/domain/ovgt.cpp` (add `Json_addUint("vane_cap", ...)` next to `pos_pct`)
+
+**Interfaces:**
+- Consumes: `BoostController::getActiveVaneCap()` (Task 3).
+
+- [ ] **Step 1: Add the telemetry field**
+
+In `src/domain/ovgt.cpp`, after the `act_temp` line, add:
+```c
+    Json_addUint("vane_cap", BoostController::getActiveVaneCap());  // active open-cap %
+```
+Confirm `boostController.h` is already included in this file (it is — `BoostController::getBprTarget()` etc. are used nearby).
+
+- [ ] **Step 2: Build the firmware**
+
+Run: `pio run -e teensy41`
+Expected: SUCCESS. (NDJSON buffer is 1280 bytes; one small field is well within budget.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/domain/ovgt.cpp
+git commit -m "feat(telemetry): emit vane_cap (active boost-scheduled open cap)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Show `vane_cap` in the host telemetry tool
+
+**Files:**
+- Modify: `tools/ovgt-telemetry/src/types.ts` (add optional `vane_cap`)
+- Modify: `tools/ovgt-telemetry/src/format.ts` (append cap to the actuator line)
+- Test: `tools/ovgt-telemetry/src/format.test.ts` (assert cap renders + fallback)
+
+**Interfaces:**
+- Consumes: firmware `vane_cap` field (Task 4).
+
+- [ ] **Step 1: Add the failing format assertions**
+
+In `tools/ovgt-telemetry/src/format.test.ts`, in the first test (`formats core telemetry fields`), add:
+```ts
+  expect(lines).toContain("cap "); // vane_cap rendered on the actuator line
+```
+Add a new test:
+```ts
+test("vane_cap renders, and falls back to -- when absent", () => {
+  expect(formatTelemetry({ ...sample, vane_cap: 29 }).join("\n")).toContain("cap 29");
+  expect(formatTelemetry(sample).join("\n")).toContain("cap --");
+});
+```
+
+- [ ] **Step 2: Run tests — verify failure**
+
+Run (from `tools/ovgt-telemetry`): `npx vitest run src/format.test.ts`
+Expected: FAIL — output has no `cap ` substring yet.
+
+- [ ] **Step 3: Add the optional type field**
+
+In `tools/ovgt-telemetry/src/types.ts`, after `act_temp?: number;`:
+```ts
+  vane_cap?: number; // active boost-scheduled vane open-cap %. Optional: absent in pre-2026-07-05 logs.
+```
+
+- [ ] **Step 4: Render it on the actuator line**
+
+In `tools/ovgt-telemetry/src/format.ts`, change the BPR/actuator line to append the cap:
+```ts
+    `BPR ${s.bpr.toFixed(2)}/${s.bpr_target.toFixed(2)}   dem ${s.dem_pct}%  pos ${s.pos_pct}%  load ${s.act_load ?? "--"}  aTemp ${s.act_temp ?? "--"}  cap ${s.vane_cap ?? "--"}`,
+```
+
+- [ ] **Step 5: Run tests + typecheck — verify pass**
+
+Run (from `tools/ovgt-telemetry`): `npx vitest run src/format.test.ts && npm run typecheck`
+Expected: PASS, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/ovgt-telemetry/src/types.ts tools/ovgt-telemetry/src/format.ts tools/ovgt-telemetry/src/format.test.ts
+git commit -m "feat(telemetry): show vane_cap on host actuator line
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full verification + flash + on-truck sanity
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full native test suite**
+
+Run: `pio test -e native`
+Expected: all suites PASS (no regression in boost/j1939/json/etc.).
+
+- [ ] **Step 2: Full host test suite**
+
+Run (from `tools/ovgt-telemetry`): `npm test`
+Expected: all PASS (store/replay need local MongoDB at 127.0.0.1:27017).
+
+- [ ] **Step 3: Firmware build (final)**
+
+Run: `pio run -e teensy41`
+Expected: SUCCESS.
+
+- [ ] **Step 4: Flash (port must be free — stop telemetry TUI first)**
+
+Free the port if held: `pkill -f "ovgt-telemetry.*index.tsx"` then flash:
+Run: `pio run -e teensy41 -t upload`
+Expected: `[SUCCESS]` and a `Programming...` trace (teensy-cli). If it reports success with no programming trace, VERIFY via Step 5 — do not assume.
+
+- [ ] **Step 5: Verify the running firmware + new field**
+
+Run: `stty -F /dev/ttyACM0 115200 raw -echo; timeout 4 cat /dev/ttyACM0 | head -c 600`
+Expected: a `{"type":"t",...}` line containing `"vane_cap":22` (≈22 at idle) alongside `dem_pct`/`pos_pct`/`act_load`. Confirms the boost-scheduled cap is live.
+
+- [ ] **Step 6: Restart the telemetry TUI (driver)**
+
+The driver runs, in their own terminal: `cd tools/ovgt-telemetry && npm start`
+Expected: actuator line now shows `... load <n>  aTemp <n>  cap <n>`. Watch `pos` riding toward `cap` under boost, plus TIT + `load` for EGT/strain.
+
+- [ ] **Step 7: On-road tuning loop (driver)**
+
+Drive and observe. To retune: edit the 5 points in `vaneCapSchedule` (`src/control/boostController.cpp`), rebuild + reflash (Steps 3-5). Revert entirely: `git checkout main` + reflash.
+```
+

--- a/docs/superpowers/specs/2026-07-05-boost-vane-cap-schedule-design.md
+++ b/docs/superpowers/specs/2026-07-05-boost-vane-cap-schedule-design.md
@@ -1,0 +1,137 @@
+# Boost-scheduled vane open-cap — design
+
+**Date:** 2026-07-05 · **Branch:** `feature/boost-vane-cap-schedule` · **Status:** approved, pre-implementation
+
+## Problem
+
+On the first loaded (trailer) run, the VGT actuator cannot hold the vanes at the
+commanded closed angle against exhaust backpressure — `pos_pct` floats *open* of
+`dem_pct`, scaling with boost (+10 at ~5 psi, +38 at 20+ psi; see memory
+`project_actuator_closure_under_load`). A parked engine-idling bench self-test
+confirmed the actuator closes fully with no backpressure (pos 1 @ demand 0), so
+the fault is torque-vs-backpressure, not electrical/mechanical/decode.
+
+The driving complaint is dynamic: the BPR PI loop **slams the vane open** (dumping
+drive pressure), boost/BPR then collapses, and the loop **slams it back closed**
+against pressure to rebuild — a violent open→re-close cycle that stresses the
+actuator. Driving gently to avoid it is not acceptable (long trip ahead).
+
+## Goal
+
+Keep the vane on a **tight leash near closed** so the PI loop can no longer fling
+it wide open, eliminating the open-slam and the subsequent close-under-pressure.
+The leash **widens slightly as boost rises** (a little relief at high boost) and
+must be trivially tunable in one place, and trivially revertible (feature branch).
+
+## Approach
+
+Replace the flat controller open-cap (`vaneOpenCapPercent = 55`) with a
+**boost → open-cap schedule**, linearly interpolated. Only the *cap* (most-open
+authority) changes; the *floor* stays `spoolPercent = 22`. Vane convention:
+0% = fully closed (max drive/boost), 88% = fully open. Higher % = more open.
+
+Resulting bands (floor 22 → scheduled cap):
+
+| Boost (psi) | open cap % | vane band |
+|---|---|---|
+| ≤ 5  | 22 | pinned 22 |
+| 10   | 25 | 22–25 |
+| 15   | 27 | 22–27 |
+| 20   | 29 | 22–29 |
+| ≥ 25 | 31 | 22–31 |
+
+### Chosen implementation: nullable schedule on `BoostConfig` (backward compatible)
+
+Add the schedule as **trailing, nullable fields** on `BoostConfig` rather than
+removing `vaneOpenCapPercent`. When the schedule pointer is null (every existing
+test), behavior is identical to today's flat cap — so the validated `boostBprStep`
+test suite is untouched. Considered but rejected: (B) replacing the scalar
+outright (breaks all test initializers for no benefit); (C) hardcoding the table
+inside `boostBprLogic.cpp` (not per-config, not native-testable in isolation, and
+the "one place to tweak" ends up buried in control logic).
+
+## Components
+
+### 1. Schedule constant — `src/control/boostController.cpp`
+The single tweakable table, editable + reflash (mirrors the legacy `pressureMap`
+pattern):
+```c
+static const VaneCapPoint vaneCapSchedule[] = {
+    { 5.0f, 22 }, { 10.0f, 25 }, { 15.0f, 27 }, { 20.0f, 29 }, { 25.0f, 31 },
+};
+```
+Wired into `boostConfig` (schedule pointer + length).
+
+### 2. Pure interpolator — `src/control/boostBprLogic.{h,cpp}` (native-tested)
+```c
+struct VaneCapPoint { float boostPsi; uint8_t capPercent; };
+
+// Boost -> open-cap %, linear between ascending points; flat outside the ends.
+// Falls back to cfg.vaneOpenCapPercent when no schedule is wired.
+uint8_t vaneOpenCapForBoost(float boostPsi, const BoostConfig &cfg);
+```
+- `boostPsi ≤ points[0]` → `points[0].capPercent`.
+- `boostPsi ≥ points[last]` → `points[last].capPercent`.
+- otherwise linear interpolation between bracketing points, rounded to nearest.
+- schedule null / len 0 → `cfg.vaneOpenCapPercent` (existing behavior).
+
+`BoostConfig` gains: `const VaneCapPoint *vaneCapSchedule;` and
+`uint8_t vaneCapScheduleLen;` (trailing; default null/0).
+
+### 3. Wire-in — `boostBprStep`, final clamp (currently line 80)
+```c
+uint8_t cap = vaneOpenCapForBoost(in.boostGaugePsi, cfg);
+return clampVane(vane, cfg.spoolPercent, cap);
+```
+No other line changes. Spool region (boost < ~3 psi) still returns `spoolPercent`
+before the cap is consulted; the spool-protect clamp (<6 psi) already pins to 22 —
+consistent with the schedule reading 22 at 5 psi.
+
+### 4. Telemetry — `vane_cap` (observability for tuning-as-you-drive)
+Firmware emits the active cap in the 10 Hz line; host shows it on the actuator
+display line so `dem` riding the cap is visible against boost.
+- `src/domain/ovgt.cpp`: `Json_addUint("vane_cap", BoostController::getActiveVaneCap())`.
+  `boostBprStep` records the cap it used into `BoostState` (new
+  `uint8_t lastVaneCap` field); `boostController.cpp` exposes it via
+  `BoostController::getActiveVaneCap()`. In the spool region the recorded cap is
+  the spool position's effective ceiling (`spoolPercent`), so the readout is
+  always meaningful.
+- `tools/ovgt-telemetry/src/types.ts`: `vane_cap?: number` (optional; absent in
+  older logs).
+- `tools/ovgt-telemetry/src/format.ts`: append `cap ${s.vane_cap ?? "--"}` to the
+  actuator line.
+
+## Safety
+
+Per decision: **no automatic EGT escape** this iteration. The schedule holds the
+vane more closed under load than today's flat cap, biasing toward higher EGT
+(today's drive touched TIT 887 °C; 17.6 % > 760 °C). Mitigation is the driver
+watching live TIT + `act_load` and reverting the branch if EGT misbehaves.
+Documented explicitly so a future iteration can add an EGT-relief override or a
+boost/BR ceiling (the design doc's current stance is deliberately "BPR only, no
+boost ceiling").
+
+## Testing (native, `pio test -e native -f test_boostBpr...`)
+
+New unit tests, TDD:
+1. `vaneOpenCapForBoost`: exact points (5→22 … 25→31); midpoints (7.5→~23,
+   12.5→26); below-min (0→22) and above-max (30→31); null-schedule fallback →
+   `vaneOpenCapPercent`.
+2. `boostBprStep` with schedule wired: at a boost where cap < 55, a BPR error that
+   would drive the vane open past the cap is clamped to the scheduled cap (not 55);
+   the floor still holds at `spoolPercent`.
+3. Existing `boostBprStep` tests (schedule null) remain green, proving backward
+   compatibility.
+
+## Rollout / revert
+
+- Branch `feature/boost-vane-cap-schedule` off `main`.
+- Flash: `pio run -e teensy41 -t upload`. Restart telemetry TUI to see `vane_cap`.
+- Revert: `git checkout main` + reflash. No data-model migration; `vane_cap` is
+  additive/optional.
+
+## Out of scope (YAGNI)
+
+- EGT-relief override / boost ceiling (noted for a future iteration).
+- Making the floor boost-dependent (floor stays 22 — validated; 18 spiked EGT).
+- Any runtime/serial tuning (compile-time only — driving-hazard policy).

--- a/docs/superpowers/specs/2026-07-05-boost-vane-cap-schedule-design.md
+++ b/docs/superpowers/specs/2026-07-05-boost-vane-cap-schedule-design.md
@@ -135,3 +135,35 @@ New unit tests, TDD:
 - EGT-relief override / boost ceiling (noted for a future iteration).
 - Making the floor boost-dependent (floor stays 22 — validated; 18 spiked EGT).
 - Any runtime/serial tuning (compile-time only — driving-hazard policy).
+
+## Validation status (as of 2026-07-06) — flashed, road-tested, MERGE-READY pending one test
+
+**Passed:**
+- 102 native + 27 host tests green. Flashed to the turbo controller (serial `00124393`
+  bootloader / `11969470` running).
+- **Light-to-mid load:** `pos` tracks the scheduled `cap` within ±1% for 94% of a drive;
+  `act_load` ~0; no BPR open-slam. Cap rides up with boost per the schedule (22→29).
+- **Hard pull (27.3 psi, TIP 42.5 psi, 2895 rpm):** vane held commanded position
+  (`pos 23` vs `dem 22`), `act_load` max **599** (no stall — vs 2220 pegging before),
+  BPR **1.56 at peak / 1.51 avg** (dead on the 1.5 target), 0% over cap. EGT ~751°C on
+  that pull.
+
+**Corrected understanding (important — the original premise was backwards):** the
+2026-07-05 "actuator stall" (pos floating +38 over cap, `act_load` pegging 2220) was
+NOT the actuator being torque-starved against backpressure. It was a **loose turbo
+bleeding drive pressure before the turbine.** Exhaust load *assists* vane closing; the
+loose turbo removed that assist so the actuator had to close the vanes alone and maxed
+out. Turbo re-secured → actuator loafs. So **`act_load` is now a loose-turbo detector**,
+and the "bulletproof actuator" purchase looks unnecessary. See memory
+`project_actuator_closure_under_load`.
+
+**Open before merge-confidence is total:**
+1. **Sustained loaded-trailer pull at 20+ psi.** Today's 27 psi was a brief hill pull;
+   the vane sat *below* the cap so the actuator was never maxed against it. If a sustained
+   loaded pull loafs like the hill did, the actuator question is closed.
+2. **EGT watch.** The tighter closure biases hotter — peak **799°C** observed. If sustained
+   loaded pulls sit north of ~780°C, add the deferred EGT-relief override or relax the top
+   of `vaneCapSchedule[]`.
+
+**To resume:** re-read this section + `project_vane_cap_schedule` memory. Tune knob is
+`vaneCapSchedule[]` in `src/control/boostController.cpp` (5 points, boost→cap %).

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ framework = arduino
 board_build.f_cpu = 600000000L
 extra_scripts = pre:cnext_build.py
 build_flags = -I include
-build_src_filter = +<*> -<pid_bench.cpp>
+build_src_filter = +<*> -<pid_bench.cpp> -<actuator_selftest.cpp>
 lib_deps =
 	https://github.com/tonton81/FlexCAN_T4
     https://github.com/adafruit/Adafruit_BusIO
@@ -28,6 +28,23 @@ lib_deps =
     adafruit/Adafruit FRAM SPI
     Wire
     SPI
+
+; Parked bench test of the VGT actuator — sweeps demand 0<->88 with no
+; backpressure and watches CAN feedback. Compiles ONLY the real Actuator scope
+; + the test main, so the teensy41 firmware is untouched.
+;   Flash test:  pio run -e actuator_test -t upload
+;   Restore:     pio run -e teensy41 -t upload
+[env:actuator_test]
+platform = teensy
+board = teensy41
+framework = arduino
+board_build.f_cpu = 600000000L
+upload_protocol = teensy-cli
+extra_scripts = pre:cnext_build.py
+build_flags = -I include
+build_src_filter = -<*> +<display/actuator.cpp> +<actuator_selftest.cpp>
+lib_deps =
+	https://github.com/tonton81/FlexCAN_T4
 
 [env:native]
 platform = native

--- a/src/actuator_selftest.cpp
+++ b/src/actuator_selftest.cpp
@@ -1,0 +1,131 @@
+// actuator_selftest.cpp — PARKED, ENGINE-OFF bench test of the VGT actuator.
+//
+// Purpose: sweep the vane demand 0% (closed) <-> 88% (open) a few times with NO
+// exhaust backpressure and watch the actuator's own CAN feedback. If it tracks
+// cleanly here but floats open under load on the road, the fault is actuator
+// torque vs. backpressure (not electrical/mechanical/decode).
+//
+// This reuses the SAME Actuator scope as the real firmware (identical CAN3 @ 500k
+// setup, identical command mapping, identical feedback decode) so the test is a
+// faithful reproduction. It is built as a SEPARATE env (`actuator_test`); the real
+// firmware (`teensy41`) is untouched. Reflash the truck with:
+//     pio run -e teensy41 -t upload
+//
+// Run it: engine OFF, ignition/key ON (so the actuator is powered), then
+//     pio run -e actuator_test -t upload
+
+#include <Arduino.h>
+#include "AppData.h"
+#include "VaneConfig.h"
+#include "actuator.hpp"   // Actuator_Initialize(), Actuator_Loop()
+
+// The Actuator scope references this global; provide our own definition so we
+// don't have to pull in the whole domain (ovgt.cpp) for a bench test.
+AppData appData;
+
+static const uint8_t CLOSED = VANE_CLOSED_PERCENT;  // 0
+static const uint8_t OPEN   = VANE_OPEN_PERCENT;    // 88
+static const uint8_t CYCLES = 4;
+static const uint8_t TRACK_TOLERANCE = 5;           // %, pass window at each endpoint
+
+// Did the actuator ever send feedback? (distinguishes "reports 0" from "silent").
+static bool feedbackSeen = false;
+
+static void noteFeedback() {
+    if (appData.actuatorRawPosition != 0 || appData.actuatorStatus != 0) {
+        feedbackSeen = true;
+    }
+}
+
+// Command `target`% for `ms`, pumping Actuator_Loop() at 100 Hz like the real
+// control loop, printing live feedback. Returns the reported position sampled at
+// the end (after the vane has had time to settle).
+static uint8_t holdAndWatch(uint8_t target, uint16_t ms, const char *label) {
+    appData.actuatorDemandedPosition = target;
+    Serial.printf(">> command %s: demand=%u%%\n", label, target);
+    uint32_t start = millis();
+    uint32_t lastPrint = 0;
+    while (millis() - start < ms) {
+        Actuator_Loop();          // send the command frame (main context, not ISR)
+        noteFeedback();
+        if (millis() - lastPrint >= 250) {
+            lastPrint = millis();
+            Serial.printf("   dem=%3u  pos=%3u  raw=%4u  motorLoad=%5u  status=0x%02X  temp=%u\n",
+                          appData.actuatorDemandedPosition,
+                          appData.actuatorReportedPosition,
+                          appData.actuatorRawPosition,
+                          appData.actuatorMotorLoad,
+                          appData.actuatorStatus,
+                          appData.actuatorTemp);
+        }
+        delay(10);
+    }
+    return appData.actuatorReportedPosition;
+}
+
+void setup() {
+    Serial.begin(115200);
+    uint32_t t0 = millis();
+    while (!Serial && millis() - t0 < 3000) { /* wait for host, but don't hang */ }
+
+    Serial.println("\n===== VGT ACTUATOR SELF-TEST (parked, engine OFF) =====");
+    Serial.println("Reuses the real Actuator scope: CAN3 @ 500k, cmd 0x4EA / fb 0x4EB.");
+    Serial.printf("Sweeping demand %u%% (closed) <-> %u%% (open), %u cycles.\n", CLOSED, OPEN, CYCLES);
+    Serial.println("Expect pos to TRACK dem within a few %% at BOTH ends with no backpressure.\n");
+
+    appData.actuatorDemandedPosition = OPEN;  // safe default before init
+    Actuator_Initialize();
+    delay(200);
+}
+
+void loop() {
+    static bool done = false;
+    if (done) {
+        // Test finished: hold OPEN (safe, no restriction) and keep feedback live.
+        Actuator_Loop();
+        noteFeedback();
+        delay(50);
+        return;
+    }
+
+    uint8_t worstCloseErr = 0;  // max |pos-0|   over cycles (want ~0)
+    uint8_t worstOpenErr  = 0;  // max |pos-88|  over cycles (want ~0)
+
+    for (uint8_t c = 1; c <= CYCLES; c++) {
+        Serial.printf("--- cycle %u/%u ---\n", c, CYCLES);
+        uint8_t posClosed = holdAndWatch(CLOSED, 3000, "CLOSED");
+        uint8_t closeErr  = (posClosed > CLOSED) ? (posClosed - CLOSED) : (CLOSED - posClosed);
+        if (closeErr > worstCloseErr) worstCloseErr = closeErr;
+
+        uint8_t posOpen = holdAndWatch(OPEN, 3000, "OPEN");
+        uint8_t openErr = (posOpen > OPEN) ? (posOpen - OPEN) : (OPEN - posOpen);
+        if (openErr > worstOpenErr) worstOpenErr = openErr;
+
+        Serial.printf("    cycle %u result: closed pos=%u (err %u), open pos=%u (err %u)\n\n",
+                      c, posClosed, closeErr, posOpen, openErr);
+    }
+
+    Serial.println("===== SUMMARY =====");
+    if (!feedbackSeen) {
+        Serial.println("RESULT: ⚠ NO ACTUATOR FEEDBACK RECEIVED.");
+        Serial.println("  The actuator never sent a 0x4EB frame. Likely NOT powered");
+        Serial.println("  (turn ignition/key ON) or a CAN3 wiring/bus issue. Test inconclusive.");
+    } else {
+        Serial.printf("Worst closed-tracking error: %u%%  (demand 0%%)\n", worstCloseErr);
+        Serial.printf("Worst open-tracking error  : %u%%  (demand %u%%)\n", worstOpenErr, OPEN);
+        bool pass = (worstCloseErr <= TRACK_TOLERANCE) && (worstOpenErr <= TRACK_TOLERANCE);
+        if (pass) {
+            Serial.println("RESULT: ✅ PASS — actuator tracks both ends unloaded.");
+            Serial.println("  => Vane hardware/electrical/decode are OK. The on-road float-open");
+            Serial.println("     under boost is TORQUE vs. EXHAUST BACKPRESSURE, as suspected.");
+        } else {
+            Serial.println("RESULT: ❌ FAIL — actuator does NOT track even with no backpressure.");
+            Serial.println("  => Fault is in the actuator/linkage/electrical itself, not just");
+            Serial.println("     backpressure. Investigate the actuator directly.");
+        }
+    }
+    Serial.println("Holding vane OPEN. Reflash real firmware: pio run -e teensy41 -t upload");
+    Serial.println("===================");
+    appData.actuatorDemandedPosition = OPEN;
+    done = true;
+}

--- a/src/control/boostBprLogic.cpp
+++ b/src/control/boostBprLogic.cpp
@@ -6,6 +6,27 @@ static uint8_t clampVane(float vane, uint8_t lo, uint8_t hi) {
     return (uint8_t)(vane + 0.5f);
 }
 
+uint8_t vaneOpenCapForBoost(float boostPsi, const BoostConfig &cfg) {
+    if (cfg.vaneCapSchedule == nullptr || cfg.vaneCapScheduleLen == 0) {
+        return cfg.vaneOpenCapPercent;
+    }
+    const VaneCapPoint *pts = cfg.vaneCapSchedule;
+    uint8_t n = cfg.vaneCapScheduleLen;
+    if (boostPsi <= pts[0].boostPsi) return pts[0].capPercent;
+    if (boostPsi >= pts[n - 1].boostPsi) return pts[n - 1].capPercent;
+    for (uint8_t i = 1; i < n; i++) {
+        if (boostPsi <= pts[i].boostPsi) {
+            float pLow = pts[i - 1].boostPsi;
+            float pHigh = pts[i].boostPsi;
+            float cLow = (float)pts[i - 1].capPercent;
+            float cHigh = (float)pts[i].capPercent;
+            float cap = cLow + (boostPsi - pLow) / (pHigh - pLow) * (cHigh - cLow);
+            return (uint8_t)(cap + 0.5f);
+        }
+    }
+    return pts[n - 1].capPercent;  // unreachable; satisfies the compiler
+}
+
 // Vane convention: vaneClosedPercent (0) = fully closed = max drive pressure /
 // boost; vaneOpenPercent (88) = fully open = no restriction. BPR = drive / boost.
 // Closing vanes raises drive faster than boost, so BPR rises. To hold BPR at

--- a/src/control/boostBprLogic.cpp
+++ b/src/control/boostBprLogic.cpp
@@ -48,6 +48,7 @@ uint8_t boostBprStep(const BoostInputs &in, const BoostConfig &cfg,
     //    spool needs. Hold a fixed spool position and flag the pending handoff.
     if (!state.inPiRegion) {
         state.wasSpooling = true;
+        state.lastVaneCap = cfg.spoolPercent;   // meaningful readout in spool region
         return clampVane((float)cfg.spoolPercent,
                          cfg.vaneClosedPercent, cfg.vaneOpenPercent);
     }
@@ -98,6 +99,8 @@ uint8_t boostBprStep(const BoostInputs &in, const BoostConfig &cfg,
     //    high-load limit cycle can only swing between the spool position and the
     //    cap (e.g. 22<->55), never stop-to-stop. Tuning spoolPercent moves both the
     //    spool hold and this floor together.
-    return clampVane(vane, cfg.spoolPercent, cfg.vaneOpenCapPercent);
+    uint8_t cap = vaneOpenCapForBoost(in.boostGaugePsi, cfg);
+    state.lastVaneCap = cap;
+    return clampVane(vane, cfg.spoolPercent, cap);
 }
 

--- a/src/control/boostBprLogic.h
+++ b/src/control/boostBprLogic.h
@@ -8,6 +8,11 @@ struct BoostInputs {
     float tipGaugePsi;     // turbine inlet (drive) pressure, gauge psi
 };
 
+struct VaneCapPoint {
+    float   boostPsi;     // schedule breakpoint (ascending)
+    uint8_t capPercent;   // open-cap at/above this boost (until the next point)
+};
+
 struct BoostConfig {
     float   bprTarget;          // default 1.5
     float   boostSpoolPsi;      // fall back to spool BELOW this (hysteresis low)
@@ -22,12 +27,18 @@ struct BoostConfig {
     uint8_t vaneOpenCapPercent;   // controller open-authority cap (< vaneOpenPercent):
                                   // the PI may never open the vane past this, blunting
                                   // the transient BPR proportional slam
+    // Boost -> open-cap schedule (ascending boostPsi). NULL / len 0 => use the flat
+    // vaneOpenCapPercent above. Tightens open authority under load so the PI cannot
+    // slam the vane wide open. Floor stays spoolPercent.
+    const VaneCapPoint *vaneCapSchedule;
+    uint8_t             vaneCapScheduleLen;
 };
 
 struct BoostState {
     float integralTerm;  // accumulated integral CONTRIBUTION, in vane-% units
     bool  wasSpooling;   // pending spool->PI handoff seed (one-shot)
     bool  inPiRegion;    // hysteretic region: false = spool, true = PI
+    uint8_t lastVaneCap; // open-cap used on the last step (for telemetry readout)
 };
 
 // Evaluate one boost control cycle and return the demanded vane position.
@@ -39,5 +50,10 @@ struct BoostState {
 // Mutates state.
 uint8_t boostBprStep(const BoostInputs &in, const BoostConfig &cfg,
                      BoostState &state, float dtSeconds);
+
+// Boost (gauge psi) -> vane open-cap %, linear between ascending schedule points,
+// flat outside the ends. Falls back to cfg.vaneOpenCapPercent when no schedule is
+// wired (cfg.vaneCapSchedule == NULL or cfg.vaneCapScheduleLen == 0).
+uint8_t vaneOpenCapForBoost(float boostPsi, const BoostConfig &cfg);
 
 #endif

--- a/src/control/boostController.cpp
+++ b/src/control/boostController.cpp
@@ -18,6 +18,14 @@ static const float HPA_TO_PSI = 0.0145038f;
 // in the tens (vane-% per unit error), unlike the brake's psi-scale kp. kp/ki were
 // validated on-truck (kp=88 was bang-bang; kp=20/ki=20 glides at sustained cruise).
 // No boost ceiling: targets BPR only (deliberate — see design doc).
+// Boost (gauge psi) -> vane open-cap (%). THE tuning knob for the closure/slam
+// strategy: edit these points + reflash. Ascending boost. Floor stays spoolPercent.
+static const VaneCapPoint vaneCapSchedule[] = {
+    { 5.0f, 22 }, { 10.0f, 25 }, { 15.0f, 27 }, { 20.0f, 29 }, { 25.0f, 31 },
+};
+static const uint8_t vaneCapScheduleLen =
+    sizeof(vaneCapSchedule) / sizeof(vaneCapSchedule[0]);
+
 static BoostConfig boostConfig = {
     1.5f,                // bprTarget
     1.5f,                // boostSpoolPsi (fall back to spool below this)
@@ -28,10 +36,11 @@ static BoostConfig boostConfig = {
     20.0f,               // kp
     20.0f,               // ki
     6.0f,                // spoolProtectBoostPsi (below this boost, don't open past spool)
-    55                   // vaneOpenCapPercent (controller may not open past this;
-                         // settled operation stays <=50%, so this clips only the kick)
+    55,                  // vaneOpenCapPercent (flat fallback if schedule unset)
+    vaneCapSchedule,     // vaneCapSchedule (boost-scheduled open cap; supersedes flat)
+    vaneCapScheduleLen   // vaneCapScheduleLen
 };
-static BoostState boostState = {0.0f, true, false};
+static BoostState boostState = {0.0f, true, false, 0};
 static uint32_t lastUpdateMs = 0;
 
 #if !BOOST_USE_BPR
@@ -98,9 +107,11 @@ void BoostController::update() {
 #else
     (void)dt;
     appData.actuatorDemandedPosition = interpolate(boostGaugePsi);
+    boostState.lastVaneCap = boostConfig.vaneOpenCapPercent;  // sane readout in MAP mode
 #endif
 }
 
 float BoostController::getBprTarget() { return boostConfig.bprTarget; }
 bool BoostController::getInPiRegion() { return boostState.inPiRegion; }
 float BoostController::getIntegralTerm() { return boostState.integralTerm; }
+uint8_t BoostController::getActiveVaneCap() { return boostState.lastVaneCap; }

--- a/src/control/boostController.h
+++ b/src/control/boostController.h
@@ -1,6 +1,8 @@
 #ifndef BoostController_h
 #define BoostController_h
 
+#include <stdint.h>
+
 class BoostController {
     public:
         static void Initialize();
@@ -13,6 +15,9 @@ class BoostController {
         // controller is in, and the integral windup that precedes the snap).
         static bool getInPiRegion();
         static float getIntegralTerm();
+        // Open-cap (%) the controller applied on the last update — for telemetry so
+        // we can see the vane riding the boost-scheduled cap. See vaneOpenCapForBoost.
+        static uint8_t getActiveVaneCap();
 };
 
 #endif

--- a/src/domain/ovgt.cpp
+++ b/src/domain/ovgt.cpp
@@ -119,6 +119,7 @@ void ovgt::handleDebug() {
     Json_addUint("pos_pct", appData.actuatorReportedPosition);
     Json_addUint("act_load", appData.actuatorMotorLoad);   // actuator motor effort (0 = coasting, ~2220 = straining)
     Json_addUint("act_temp", appData.actuatorTemp);        // actuator body temp (raw byte from feedback frame)
+    Json_addUint("vane_cap", BoostController::getActiveVaneCap());  // active boost-scheduled open-cap %
     Json_addStr("reset_cause", resetCauseName(SystemHealth_resetCauseCode()));
     Json_addUint("boot_count", SystemHealth_bootCount());
     Json_addBool("crash", bootCrashPresent);

--- a/src/domain/ovgt.cpp
+++ b/src/domain/ovgt.cpp
@@ -117,6 +117,8 @@ void ovgt::handleDebug() {
     Json_addBool("ce_settled", ceSettled);
     Json_addUint("dem_pct", appData.actuatorDemandedPosition);
     Json_addUint("pos_pct", appData.actuatorReportedPosition);
+    Json_addUint("act_load", appData.actuatorMotorLoad);   // actuator motor effort (0 = coasting, ~2220 = straining)
+    Json_addUint("act_temp", appData.actuatorTemp);        // actuator body temp (raw byte from feedback frame)
     Json_addStr("reset_cause", resetCauseName(SystemHealth_resetCauseCode()));
     Json_addUint("boot_count", SystemHealth_bootCount());
     Json_addBool("crash", bootCrashPresent);

--- a/test/test_boost_bpr_logic/test_boost_bpr_logic.cpp
+++ b/test/test_boost_bpr_logic/test_boost_bpr_logic.cpp
@@ -18,6 +18,8 @@ static BoostConfig makeConfig(void) {
     cfg.ki = 20.0f;
     cfg.spoolProtectBoostPsi = 6.0f;
     cfg.vaneOpenCapPercent = 55;
+    cfg.vaneCapSchedule = nullptr;   // existing tests: flat-cap path
+    cfg.vaneCapScheduleLen = 0;
     return cfg;
 }
 
@@ -224,8 +226,48 @@ void test_hysteresis_enters_pi_above_high(void) {
     TEST_ASSERT_TRUE(st.inPiRegion);
 }
 
+static const VaneCapPoint kSchedule[] = {
+    {5.0f, 22}, {10.0f, 25}, {15.0f, 27}, {20.0f, 29}, {25.0f, 31},
+};
+
+void test_vane_cap_null_schedule_falls_back_to_flat(void) {
+    BoostConfig cfg = makeConfig();          // schedule null, vaneOpenCapPercent 55
+    TEST_ASSERT_EQUAL_UINT8(55, vaneOpenCapForBoost(10.0f, cfg));
+}
+
+void test_vane_cap_exact_points(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    TEST_ASSERT_EQUAL_UINT8(22, vaneOpenCapForBoost(5.0f, cfg));
+    TEST_ASSERT_EQUAL_UINT8(25, vaneOpenCapForBoost(10.0f, cfg));
+    TEST_ASSERT_EQUAL_UINT8(29, vaneOpenCapForBoost(20.0f, cfg));
+    TEST_ASSERT_EQUAL_UINT8(31, vaneOpenCapForBoost(25.0f, cfg));
+}
+
+void test_vane_cap_clamps_outside_ends(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    TEST_ASSERT_EQUAL_UINT8(22, vaneOpenCapForBoost(0.0f, cfg));   // below first
+    TEST_ASSERT_EQUAL_UINT8(22, vaneOpenCapForBoost(2.0f, cfg));   // below first
+    TEST_ASSERT_EQUAL_UINT8(31, vaneOpenCapForBoost(30.0f, cfg));  // above last
+}
+
+void test_vane_cap_interpolates_midpoint(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    // 12.5 psi: 25 + (2.5/5)*(27-25) = 26
+    TEST_ASSERT_EQUAL_UINT8(26, vaneOpenCapForBoost(12.5f, cfg));
+}
+
 int main(int, char **) {
     UNITY_BEGIN();
+    RUN_TEST(test_vane_cap_null_schedule_falls_back_to_flat);
+    RUN_TEST(test_vane_cap_exact_points);
+    RUN_TEST(test_vane_cap_clamps_outside_ends);
+    RUN_TEST(test_vane_cap_interpolates_midpoint);
     RUN_TEST(test_spool_region_holds_spool_position);
     RUN_TEST(test_bpr_below_target_closes);
     RUN_TEST(test_bpr_above_target_opens);

--- a/test/test_boost_bpr_logic/test_boost_bpr_logic.cpp
+++ b/test/test_boost_bpr_logic/test_boost_bpr_logic.cpp
@@ -262,8 +262,36 @@ void test_vane_cap_interpolates_midpoint(void) {
     TEST_ASSERT_EQUAL_UINT8(26, vaneOpenCapForBoost(12.5f, cfg));
 }
 
+void test_schedule_clamps_open_slam_to_scheduled_cap(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    BoostInputs in;
+    in.boostGaugePsi = 20.0f;   // schedule cap = 29
+    in.tipGaugePsi = 30.0f;     // bpr 1.5 > target -> wants to open fully
+    BoostState st = {0.0f, false, true, 0};
+    uint8_t vane = boostBprStep(in, cfg, st, 0.01f);
+    TEST_ASSERT_EQUAL_UINT8(29, vane);          // clamped to scheduled cap, not 55
+    TEST_ASSERT_EQUAL_UINT8(29, st.lastVaneCap); // cap recorded for telemetry
+}
+
+void test_spool_region_records_spool_as_cap(void) {
+    BoostConfig cfg = makeConfig();
+    cfg.vaneCapSchedule = kSchedule;
+    cfg.vaneCapScheduleLen = 5;
+    BoostInputs in;
+    in.boostGaugePsi = 1.0f;    // spool region
+    in.tipGaugePsi = 0.5f;
+    BoostState st = {0.0f, false, false, 0};
+    uint8_t vane = boostBprStep(in, cfg, st, 0.01f);
+    TEST_ASSERT_EQUAL_UINT8(cfg.spoolPercent, vane);
+    TEST_ASSERT_EQUAL_UINT8(cfg.spoolPercent, st.lastVaneCap); // meaningful readout
+}
+
 int main(int, char **) {
     UNITY_BEGIN();
+    RUN_TEST(test_schedule_clamps_open_slam_to_scheduled_cap);
+    RUN_TEST(test_spool_region_records_spool_as_cap);
     RUN_TEST(test_vane_cap_null_schedule_falls_back_to_flat);
     RUN_TEST(test_vane_cap_exact_points);
     RUN_TEST(test_vane_cap_clamps_outside_ends);

--- a/tools/ovgt-telemetry/src/format.test.ts
+++ b/tools/ovgt-telemetry/src/format.test.ts
@@ -17,6 +17,12 @@ test("formats core telemetry fields", () => {
   expect(lines).toContain("BPR 0.00/1.00");
   expect(lines).toContain("dem 25%");
   expect(lines).toContain("MCU 45.3C");
+  expect(lines).toContain("cap "); // vane_cap rendered on the actuator line
+});
+
+test("vane_cap renders, and falls back to -- when absent", () => {
+  expect(formatTelemetry({ ...sample, vane_cap: 29 }).join("\n")).toContain("cap 29");
+  expect(formatTelemetry(sample).join("\n")).toContain("cap --");
 });
 
 test("ce_pct -1 renders as -- and settled drops the ~", () => {

--- a/tools/ovgt-telemetry/src/format.ts
+++ b/tools/ovgt-telemetry/src/format.ts
@@ -5,7 +5,7 @@ export function formatTelemetry(s: TelemetrySample): string[] {
   return [
     `mode ${s.mode}   brake ${s.brake ? "ON" : "off"}`,
     `boost ${s.boost_psi.toFixed(1)}psi  BR ${s.br.toFixed(2)}  TIP ${s.tip_psi.toFixed(1)}psi`,
-    `BPR ${s.bpr.toFixed(2)}/${s.bpr_target.toFixed(2)}   dem ${s.dem_pct}%  pos ${s.pos_pct}%`,
+    `BPR ${s.bpr.toFixed(2)}/${s.bpr_target.toFixed(2)}   dem ${s.dem_pct}%  pos ${s.pos_pct}%  load ${s.act_load ?? "--"}  aTemp ${s.act_temp ?? "--"}`,
     `CIT ${s.cit_c.toFixed(1)}C  COT ${s.cot_c.toFixed(1)}C  TIT ${s.tit_c}C  MCU ${s.mcu_c.toFixed(1)}C`,
     `CE ${ce}`,
   ];

--- a/tools/ovgt-telemetry/src/format.ts
+++ b/tools/ovgt-telemetry/src/format.ts
@@ -5,7 +5,7 @@ export function formatTelemetry(s: TelemetrySample): string[] {
   return [
     `mode ${s.mode}   brake ${s.brake ? "ON" : "off"}`,
     `boost ${s.boost_psi.toFixed(1)}psi  BR ${s.br.toFixed(2)}  TIP ${s.tip_psi.toFixed(1)}psi`,
-    `BPR ${s.bpr.toFixed(2)}/${s.bpr_target.toFixed(2)}   dem ${s.dem_pct}%  pos ${s.pos_pct}%  load ${s.act_load ?? "--"}  aTemp ${s.act_temp ?? "--"}`,
+    `BPR ${s.bpr.toFixed(2)}/${s.bpr_target.toFixed(2)}   dem ${s.dem_pct}%  pos ${s.pos_pct}%  load ${s.act_load ?? "--"}  aTemp ${s.act_temp ?? "--"}  cap ${s.vane_cap ?? "--"}`,
     `CIT ${s.cit_c.toFixed(1)}C  COT ${s.cot_c.toFixed(1)}C  TIT ${s.tit_c}C  MCU ${s.mcu_c.toFixed(1)}C`,
     `CE ${ce}`,
   ];

--- a/tools/ovgt-telemetry/src/index.tsx
+++ b/tools/ovgt-telemetry/src/index.tsx
@@ -6,12 +6,18 @@ import React from "react";
 import { SerialPort } from "serialport";
 import { App } from "./app";
 import { parseLine } from "./parse";
-import { pickTeensyPort, SerialLink, type SerialStream } from "./serial";
+import { pickTeensyPort, teensyByIdPath, SerialLink, type SerialStream } from "./serial";
 import { MongoStore } from "./store";
 import type { SettleEvent, TelemetrySample } from "./types";
 
+// OVGT turbo controller USB serial (RUNNING-firmware serial — a Teensy reports a
+// DIFFERENT serial in HalfKay bootloader). Override with --serial or OVGT_SERIAL.
+// vulCAN logger is 16550620; never connect to it by accident.
+const OVGT_TEENSY_SERIAL = process.env.OVGT_SERIAL ?? "11969470";
+
 interface Args {
   port?: string;
+  serial?: string;
   mongo: string;
   noMongo: boolean;
   label: string;
@@ -23,6 +29,7 @@ function parseArgs(argv: string[]): Args {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--port") args.port = argv[++i];
+    else if (a === "--serial") args.serial = argv[++i];
     else if (a === "--mongo") args.mongo = argv[++i]!;
     else if (a === "--no-mongo") args.noMongo = true;
     else if (a === "--label") args.label = argv[++i]!;
@@ -128,12 +135,19 @@ async function main(): Promise<void> {
     }
   };
 
+  const serial = args.serial ?? OVGT_TEENSY_SERIAL;
   let portPath = args.port;
+  let boardFound = false;
   if (!portPath) {
-    portPath = pickTeensyPort(await SerialPort.list());
+    // Resolve by serial. If present now → its stable by-id symlink. If absent →
+    // STILL the by-id symlink (constructed), so open() keeps retrying THIS board
+    // instead of ever falling back to a random /dev/ttyACM* (e.g. vulCAN).
+    const found = pickTeensyPort(await SerialPort.list(), serial);
+    boardFound = found !== undefined;
+    portPath = found ?? teensyByIdPath(serial);
   }
   const link = new SerialLink({
-    open: () => new SerialPort({ path: portPath ?? "/dev/ttyACM0", baudRate: 115200 }) as unknown as SerialStream,
+    open: () => new SerialPort({ path: portPath!, baudRate: 115200 }) as unknown as SerialStream,
     onLine: handleLine,
     onStatus: (st, d) => feed.emit("status", d ? `${st}: ${d}` : st),
   });
@@ -148,7 +162,11 @@ async function main(): Promise<void> {
 
   // Start the source AFTER mount so Root's feed subscription is already live.
   setImmediate(() => {
-    if (!portPath) feed.emit("log", "no Teensy found (VID 16c0); trying /dev/ttyACM0 — or pass --port");
+    if (!args.port) {
+      feed.emit("log", boardFound
+        ? `OVGT board serial ${serial} → ${portPath}`
+        : `waiting for OVGT board serial ${serial} (${portPath}); refusing any other device`);
+    }
     if (store) feed.emit("log", `mongo: logging to ${args.mongo} db=ovgt`);
     link.start();
   });

--- a/tools/ovgt-telemetry/src/serial.test.ts
+++ b/tools/ovgt-telemetry/src/serial.test.ts
@@ -1,15 +1,34 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { expect, test, vi } from "vitest";
-import { pickTeensyPort, SerialLink, type SerialStream } from "./serial";
+import { pickTeensyPort, teensyByIdPath, SerialLink, type SerialStream } from "./serial";
 
-test("pickTeensyPort finds the 16c0 device, case-insensitive", () => {
+test("pickTeensyPort finds the sole 16c0 device, case-insensitive", () => {
   const ports = [
     { path: "/dev/ttyS0", vendorId: undefined },
     { path: "/dev/ttyACM0", vendorId: "16C0", productId: "0483" },
   ];
-  expect(pickTeensyPort(ports)).toBe("/dev/ttyACM0");
+  expect(pickTeensyPort(ports)).toBe("/dev/ttyACM0"); // one Teensy, no serial → its path
   expect(pickTeensyPort([{ path: "/dev/ttyS0" }])).toBeUndefined();
+});
+
+test("pickTeensyPort selects the RIGHT board by serial when several are present", () => {
+  const ports = [
+    { path: "/dev/ttyACM1", vendorId: "16c0", productId: "0483", serialNumber: "16550620" }, // vulCAN
+    { path: "/dev/ttyACM2", vendorId: "16c0", productId: "0483", serialNumber: "11969470" }, // OVGT
+  ];
+  // Targets OVGT by serial → its stable by-id symlink, NOT vulCAN's ttyACM1.
+  expect(pickTeensyPort(ports, "11969470")).toBe(teensyByIdPath("11969470"));
+  expect(pickTeensyPort(ports, "16550620")).toBe(teensyByIdPath("16550620"));
+});
+
+test("pickTeensyPort fails CLOSED: target absent, or ambiguous with no target", () => {
+  const ports = [
+    { path: "/dev/ttyACM1", vendorId: "16c0", serialNumber: "16550620" },
+    { path: "/dev/ttyACM2", vendorId: "16c0", serialNumber: "11969470" },
+  ];
+  expect(pickTeensyPort(ports, "99999999")).toBeUndefined(); // requested board not plugged in
+  expect(pickTeensyPort(ports)).toBeUndefined(); // 2 Teensies, no target → refuse to guess
 });
 
 // Fake serial stream: inner PassThrough feeds `pipe`; writes are recorded.

--- a/tools/ovgt-telemetry/src/serial.ts
+++ b/tools/ovgt-telemetry/src/serial.ts
@@ -4,13 +4,34 @@ export interface PortLike {
   path: string;
   vendorId?: string;
   productId?: string;
+  serialNumber?: string;
 }
 
 const TEENSY_VENDOR_ID = "16c0";
 
-export function pickTeensyPort(ports: PortLike[]): string | undefined {
-  const teensy = ports.find((p) => (p.vendorId ?? "").toLowerCase() === TEENSY_VENDOR_ID);
-  return teensy?.path;
+// The stable, serial-keyed symlink udev creates for a running Teensy. Unlike
+// /dev/ttyACM*, it always points at THIS specific board and survives USB
+// re-enumeration — so we open the board we mean, never "device number 1".
+export function teensyByIdPath(serial: string): string {
+  return `/dev/serial/by-id/usb-Teensyduino_USB_Serial_${serial}-if00`;
+}
+
+// Resolve the port for a specific Teensy by USB serial number. Matching by
+// serial (not by /dev path, not by vendor alone) is what stops us grabbing the
+// WRONG board when several 16c0 Teensies are plugged in — e.g. the OVGT turbo
+// controller vs the vulCAN logger, which share vendor 16c0. Returns the stable
+// by-id symlink for the match. Fails CLOSED: undefined when the requested board
+// is absent (or when no target is given and several Teensies are present), so
+// callers refuse to connect rather than talking to a random device.
+export function pickTeensyPort(ports: PortLike[], targetSerial?: string): string | undefined {
+  const teensies = ports.filter((p) => (p.vendorId ?? "").toLowerCase() === TEENSY_VENDOR_ID);
+  const match = targetSerial
+    ? teensies.find((p) => p.serialNumber === targetSerial)
+    : teensies.length === 1
+      ? teensies[0]
+      : undefined;
+  if (!match) return undefined;
+  return match.serialNumber ? teensyByIdPath(match.serialNumber) : match.path;
 }
 
 // Minimal surface shared by a real SerialPort and the test's fake stream.

--- a/tools/ovgt-telemetry/src/types.ts
+++ b/tools/ovgt-telemetry/src/types.ts
@@ -19,6 +19,8 @@ export interface TelemetrySample {
   ce_settled: boolean;
   dem_pct: number;
   pos_pct: number;
+  act_load?: number; // actuator motor effort (0 = coasting, ~2220 = straining). Optional: absent in pre-2026-07-05 logs.
+  act_temp?: number; // actuator body temp (raw feedback byte). Optional: absent in pre-2026-07-05 logs.
   brake: boolean;
 }
 

--- a/tools/ovgt-telemetry/src/types.ts
+++ b/tools/ovgt-telemetry/src/types.ts
@@ -21,6 +21,7 @@ export interface TelemetrySample {
   pos_pct: number;
   act_load?: number; // actuator motor effort (0 = coasting, ~2220 = straining). Optional: absent in pre-2026-07-05 logs.
   act_temp?: number; // actuator body temp (raw feedback byte). Optional: absent in pre-2026-07-05 logs.
+  vane_cap?: number; // active boost-scheduled vane open-cap %. Optional: absent in pre-2026-07-05 logs.
   brake: boolean;
 }
 


### PR DESCRIPTION
## What this does

Replaces the flat controller vane open-cap (`vaneOpenCapPercent = 55`) with a
**boost → open-cap schedule**, so the BPR PI loop can no longer slam the vane wide
open under load. The vane rides a tight near-closed band that widens with boost
(cap 22→31 across 5→25 psi); the closed floor stays `spoolPercent = 22`.

**Tune knob** (one place, edit + reflash): `vaneCapSchedule[]` in
`src/control/boostController.cpp`.

## How

- Pure, native-tested interpolator `vaneOpenCapForBoost(boostPsi, cfg)` in
  `boostBprLogic` (linear between points, flat outside, falls back to the flat cap when
  no schedule is wired — so existing `boostBprStep` tests stay green untouched).
- Schedule wired as **nullable trailing fields** on `BoostConfig` (zero churn to
  validated tests).
- Active cap surfaced as telemetry `vane_cap` (firmware + host display) so you can watch
  `pos` ride the cap against boost.

## On-truck validation (2026-07-05 → 06)

- 102 native + 27 host tests green.
- **Light-to-mid load:** `pos` tracks `cap` ±1% for 94% of a drive; `act_load` ~0; no slam.
- **27.3 psi hill pull (TIP 42.5, 2895 rpm):** vane held (`pos 23`/`dem 22`), `act_load`
  max **599** (no stall, vs 2220 pegging pre-fix), **BPR 1.56 peak / 1.51 avg** — dead on
  the 1.5 target. EGT ~751°C.

### Corrected understanding (the original premise was backwards)
The 2026-07-05 "actuator stall" (vane floating +38 over cap, `act_load` pegging 2220) was
**not** the actuator being torque-starved by backpressure. It was a **loose turbo bleeding
drive pressure before the turbine** — exhaust load *assists* vane closing, and the loose
joint removed that assist. Turbo re-secured → actuator loafs. `act_load` is now effectively
a loose-turbo detector, and the "bulletproof actuator" purchase looks unnecessary.

## Open before full merge confidence
1. **Sustained loaded-trailer pull at 20+ psi** — today's 27 psi was brief and the vane sat
   below the cap (actuator never maxed against it).
2. **EGT watch** — tighter closure biases hotter (peak 799°C). If sustained loaded pulls sit
   >~780°C, add the deferred EGT-relief override or relax the top of the schedule.

## Also bundled (rode along on this branch, unrelated to vane-cap)
- `fix(telemetry): select serial by USB serial-id, fail closed` — the host telemetry tool
  now targets the OVGT controller by USB serial (`/dev/serial/by-id`), never a bare
  `/dev/ttyACM*`, so it can't grab the vulCAN logger by accident. Prompted by a real
  wrong-board flash incident.

## Test plan
- `pio test -e native` (all green) · `npm test` in `tools/ovgt-telemetry` (needs local Mongo)
- Flash `pio run -e teensy41 -t upload`; confirm `vane_cap` in the 10 Hz line.

Full design + validation status: `docs/superpowers/specs/2026-07-05-boost-vane-cap-schedule-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
